### PR TITLE
fix html parser handling

### DIFF
--- a/etl/solids/transform_parsed_article_content.py
+++ b/etl/solids/transform_parsed_article_content.py
@@ -16,14 +16,11 @@ def parse_raw_content(context: Context, raw_content: list[RawContent]) -> list[P
         try:
             return ParsedContent(
                 article_id=raw.article_id,
-                # don't think this will work since we're not in the same scope as when we pull the rows
-                # the first time; if it does, great! if it doesn't, can intentionally join to get data
                 content=parser.extract(raw.content, raw.article.rss_feed.parser_config),
                 added_at=runtime)
-        except AttributeError as e:
-            context.log.error(
+        except AttributeError:
+            context.log.debug(
                 f"Article id {raw.article_id} with parser_config {raw.article.rss_feed.parser_config} failed to parse.")
-            raise e
 
     # filter out None values for when we have a try/except statement implemented
     return list(filter(None, [_raw_to_parsed(raw) for raw in raw_content]))


### PR DESCRIPTION
remove comments noting something might not work (it does, yay sqlalchemy), and log the parser error then silently continue and don't raise an error. If we can't parse something, that's okay for now