### PR TITLE
Fix article cluster insert

### DIFF
--- a/etl/solids/compute_article_clusters.py
+++ b/etl/solids/compute_article_clusters.py
@@ -120,7 +120,7 @@ def cluster_articles(context: Context, tfidf: TFIDF) -> list[ArticleCluster]:
             begin=str_to_datetime(context.solid_config["begin"]),
             end=str_to_datetime(context.solid_config["end"]),
             added_at=str_to_datetime(context.solid_config["runtime"]),
-            articles=[tfidf.index_to_article[idx].dict() for idx in rows]
+            articles=[tfidf.index_to_article[idx] for idx in rows]
         ) for _, rows in clusters_and_rows
     ]
 


### PR DESCRIPTION
attempt to fix the issue by using a dataclass instead of a pydantic model; for some reason, the latter drops the sqlalchemy state information, and the former doesn't. I am hopeful that the lack of "reconstructing" an Article object will make the ArticleCluster insert work properly