### PR TITLE
Bump up k8s nodes

### DIFF
--- a/infrastructure/etl/__main__.py
+++ b/infrastructure/etl/__main__.py
@@ -54,7 +54,7 @@ k8s = do.KubernetesCluster("ptb-k8s",
                                name="main-pool",
                                size="s-2vcpu-4gb",
                                min_nodes=2,
-                               max_nodes=4,
+                               max_nodes=3,
                                auto_scale=True
                            ))
 


### PR DESCRIPTION
hitting 137 exit codes, which means we need more memory on our nodes; this bumps up the node size to 4gb, pulls down the max node number to 3