### PR TITLE
better fix for rss link bug

### DIFF
--- a/etl/solids/extract_article_metadata.py
+++ b/etl/solids/extract_article_metadata.py
@@ -62,7 +62,11 @@ def get_raw_feeds(context: Context, rss_feeds: list[RssFeed]) -> list[RawFeed]:
                     entries=entries,
                     source_id=rss_feed.source_id,
                     rss_feed_id=rss_feed.id,
-                    **raw.feed
+                    title=raw.feed.title,
+                    # this is still aliased as 'link' in the model because we used to
+                    # unpack the whole raw.feed object into this; couldn't hurt to update
+                    # the model and all uses of it to say url and remove the alias
+                    link=rss_feed.url
                 )
             except pydantic.ValidationError as e:
                 context.log.debug(f"The error: {e}, for rss_feed of id {rss_feed.id} and url {rss_feed.url}")

--- a/etl/tests/unit/solids/test_extract_article_metadata.py
+++ b/etl/tests/unit/solids/test_extract_article_metadata.py
@@ -84,7 +84,7 @@ def test_get_raw_feeds():
     rss_feeds = [
         RssFeed(
             source_id=idx,
-            url="https://fake.com",
+            url="https://www.fake.com",
             parser_config={"fake": "config"}
         ) for idx, n in enumerate(source_names)]
 
@@ -138,50 +138,6 @@ def test_get_raw_feeds():
                                  link=parsed.feed.link,
                                  source_id=rss_feeds[idx].source_id,
                                  rss_feed_id=rss_feeds[idx].id)
-
-
-def test_get_raw_feeds_validation_error():
-    source_names = get_source_names()[:3]
-
-    rss_feeds = [
-        RssFeed(
-            source_id=idx,
-            url="https://fake.com",
-            parser_config={"fake": "config"}
-        ) for idx, n in enumerate(source_names)]
-
-    parsed = feedparser.FeedParserDict({
-        "status": 200,
-        "feed": feedparser.FeedParserDict(
-            {"updated": datetime_to_str(get_current_time()),
-             "linkBadName": "https://www.fake.com",
-             "title": "myfeed_title",
-             "subtitle": "myfeed_subtitle"
-             }),
-        "entries": [feedparser.FeedParserDict(
-            {"title": "fake_title",
-             "summary": "fake_summary",
-             "published": datetime_to_str(get_current_time()),
-             "link": "https://www.fake.com",
-             "author": "pencil mcpen"
-             })]
-    })
-
-    def _test_rss_parser(_init_context):
-        rss_mock = mock_rss_parser()
-        rss_mock.parse = Mock(return_value=parsed)
-        return rss_mock
-
-    result: SolidExecutionResult = execute_solid(
-        get_raw_feeds,
-        input_values={"rss_feeds": rss_feeds},
-        mode_def=ModeDefinition(name="test",
-                                resource_defs={"rss_parser": ResourceDefinition(_test_rss_parser),
-                                               "database_client": mock_database_client})
-    )
-
-    assert result.success
-    assert len(result.output_value()) == 0
 
 
 def test_get_new_raw_feed_entries():


### PR DESCRIPTION
explicitly pass the 'link' for RawFeed from the RssFeed so that we don't depend on the feed publisher to do even that correctly, update tests accordingly