### PR TITLE
Use added at as load tag

### DIFF
--- a/etl/pipelines/compute_term_counts.py
+++ b/etl/pipelines/compute_term_counts.py
@@ -44,16 +44,15 @@ def compute_term_counts():
 # sensors
 @asset_sensor(asset_key=AssetKey("parsedcontent_table"), pipeline_name="compute_term_counts", mode="cloud")
 def compute_counts_sensor(context: SensorEvaluationContext, asset_event: EventLogEntry):
-    parsed_content_runtime_tag = asset_event.dagster_event.event_specific_data.materialization.tags["runtime"]
-    term_counts_runtime = datetime_to_str(get_current_time())
+    runtime_tag = asset_event.dagster_event.event_specific_data.materialization.tags["runtime"]
 
     yield RunRequest(
         run_key=context.cursor,
         run_config={
             "solids": {
-                "get_parsed_content": {"config": {"begin": parsed_content_runtime_tag,
-                                                  "end": parsed_content_runtime_tag}},
-                "compute_counts": {"config": {"runtime": term_counts_runtime}},
-                "load_term_counts": {"config": {"runtime": term_counts_runtime}}}
+                "get_parsed_content": {"config": {"begin": runtime_tag,
+                                                  "end": runtime_tag}},
+                "compute_counts": {"config": {"runtime": runtime_tag}},
+                "load_term_counts": {"config": {"runtime": runtime_tag}}}
         },
     )

--- a/etl/pipelines/extract_raw_article_content.py
+++ b/etl/pipelines/extract_raw_article_content.py
@@ -59,8 +59,7 @@ def extract_raw_article_content():
 # schedules/sensors
 @asset_sensor(asset_key=AssetKey("article_table"), pipeline_name="extract_raw_article_content", mode="cloud")
 def extract_raw_article_content_sensor(context: SensorEvaluationContext, asset_event: EventLogEntry):
-    article_runtime_tag = asset_event.dagster_event.event_specific_data.materialization.tags["runtime"]
-    raw_content_runtime = datetime_to_str(get_current_time())
+    runtime_tag = asset_event.dagster_event.event_specific_data.materialization.tags["runtime"]
 
     yield RunRequest(
         run_key=context.cursor,
@@ -68,9 +67,9 @@ def extract_raw_article_content_sensor(context: SensorEvaluationContext, asset_e
             "solids": {
                 # we specify both begin and end as the same so it operates in "batch" or "tag" mode,
                 # where we use the exact timestamp as a batch tag to pull the right articles
-                "get_articles": {"config": {"begin": article_runtime_tag, "end": article_runtime_tag}},
-                "request_raw_content": {"config": {"runtime": raw_content_runtime}},
-                "load_raw_content": {"config": {"runtime": raw_content_runtime}}
+                "get_articles": {"config": {"begin": runtime_tag, "end": runtime_tag}},
+                "request_raw_content": {"config": {"runtime": runtime_tag}},
+                "load_raw_content": {"config": {"runtime": runtime_tag}}
             }
         }
     )

--- a/etl/pipelines/transform_parsed_article_content.py
+++ b/etl/pipelines/transform_parsed_article_content.py
@@ -55,8 +55,7 @@ def transform_parsed_article_content():
 # schedules/sensors
 @asset_sensor(asset_key=AssetKey("rawcontent_table"), pipeline_name="transform_parsed_article_content", mode="cloud")
 def transform_parsed_article_content_sensor(context: SensorEvaluationContext, asset_event: EventLogEntry):
-    raw_content_runtime_tag = asset_event.dagster_event.event_specific_data.materialization.tags["runtime"]
-    parsed_content_runtime = datetime_to_str(get_current_time())
+    runtime_tag = asset_event.dagster_event.event_specific_data.materialization.tags["runtime"]
 
     yield RunRequest(
         run_key=context.cursor,
@@ -64,9 +63,9 @@ def transform_parsed_article_content_sensor(context: SensorEvaluationContext, as
             "solids": {
                 # we specify both begin and end as the same so it operates in "batch" or "tag" mode,
                 # where we use the exact timestamp as a batch tag to pull the right articles
-                "get_raw_content": {"config": {"begin": raw_content_runtime_tag, "end": raw_content_runtime_tag}},
-                "parse_raw_content": {"config": {"runtime": parsed_content_runtime}},
-                "load_parsed_content": {"config": {"runtime": parsed_content_runtime}}
+                "get_raw_content": {"config": {"begin": runtime_tag, "end": runtime_tag}},
+                "parse_raw_content": {"config": {"runtime": runtime_tag}},
+                "load_parsed_content": {"config": {"runtime": runtime_tag}}
             }
         }
     )

--- a/etl/repositories.py
+++ b/etl/repositories.py
@@ -1,7 +1,7 @@
 from dagster import repository
 
 from etl.pipelines.compute_article_clusters import compute_article_clusters, article_cluster_schedule_12h,\
-    article_cluster_schedule_1d, article_cluster_schedule_3d
+    article_cluster_schedule_1d, article_cluster_schedule_3d, compute_article_clusters_sensor
 from etl.pipelines.compute_term_counts import compute_term_counts, compute_counts_sensor
 from etl.pipelines.extract_article_metadata import extract_article_metadata, main_schedule
 from etl.pipelines.transform_parsed_article_content import transform_parsed_article_content,\
@@ -30,6 +30,7 @@ def ptb_repository():
         article_cluster_schedule_1d,
         article_cluster_schedule_3d,
         # sensors
+        compute_article_clusters_sensor,
         extract_raw_article_content_sensor,
         transform_parsed_article_content_sensor,
         compute_counts_sensor,


### PR DESCRIPTION
Uses the added_at field as a load tag, so makes sure that the timestamp flowing from initial extraction all the way through to cluster creation is consistent. Should help with logging/debugging and generally querying/thinking about things. Also adds a sensor for the article clustering 1-day process (will need to turn off the one-day schedule).